### PR TITLE
Retweets use original retweeted text.

### DIFF
--- a/Lib/SimpleLifestream/Providers/Twitter.php
+++ b/Lib/SimpleLifestream/Providers/Twitter.php
@@ -158,13 +158,17 @@ class Twitter extends Adapter
     /** inline {@inheritdoc} */
     protected function filterResponse($value)
     {
+        $tweet = $value['text'];
+        if (isset($value['retweeted_status'])) {
+            $tweet = 'RT @' . $value['retweeted_status']['user']['screen_name'] . ': ' . $value['retweeted_status']['text'];
+        }
         return array(
             'service'  => 'twitter',
             'type'     => 'tweeted',
             'resource' => $this->settings['resource'],
             'stamp'    => (int) strtotime($value['created_at']),
             'url'      => 'http://twitter.com/#!/' . $this->settings['resource'] . '/status/' . $value['id_str'],
-            'text'     => $value['text']
+            'text'     => $tweet
         );
     }
 }


### PR DESCRIPTION
Certain tweets are longer than 140 characters; notably, retweets that contain a link may result in long tweets that are truncated by Twitter API for compatibility reasons. The original retweet text is available in the API, and this update uses that text. It also prepends the tweet with "RT @UserNameHere" to match Twitter's style.
