### PR TITLE
cache_dir uses upload_tmp_dir when set

### DIFF
--- a/Lib/SimpleLifestream/Cache/File.php
+++ b/Lib/SimpleLifestream/Cache/File.php
@@ -24,7 +24,7 @@ class File extends Handler implements ItemInterface
     public function __construct(array $config = array())
     {
         parent::__construct(array_merge(array(
-            'cache_dir' => sys_get_temp_dir(),
+            'cache_dir' => ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir(),
             'cache_prefix' => 'SimpleLifestreamFileCache',
             'cache_suffix' => 'cache',
         ), $config));


### PR DESCRIPTION
Sometimes the system cache directory is inaccessible (cf. `open_basedir`) or otherwise undesirable. Developers often make this known by setting the `upload_tmp_dir`. This PR should resolve any errors encountered when using this library while `open_basedir` is set.

See: http://stackoverflow.com/a/7511767
